### PR TITLE
fix: Weird snap behavior (Android)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -518,6 +518,28 @@ export class ScrollBottomSheet<T extends any> extends Component<Props<T>> {
           clockRunning(this.animationClock)
         ),
         [
+          this.didScrollUpAndPullDown,
+          this.setTranslationY,
+          set(this.tempDestSnapPoint, add(snapPoints[0], this.extraOffset)),
+          cond(not(this.isManuallySetValue), set(this.nextSnapIndex, 0)),
+          set(
+            this.destSnapPoint,
+            cond(
+              this.isManuallySetValue,
+              this.manualYOffset,
+              this.calculateNextSnapPoint()
+            )
+          ),
+          cond(this.isManuallySetValue, [
+            set(this.animationFinished, 0)
+          ]),
+          set(
+            this.lastSnap,
+            sub(
+              this.destSnapPoint,
+              cond(eq(this.scrollUpAndPullDown, 1), this.lastStartScrollY, 0)
+            )
+          ),
           runTiming({
             clock: this.animationClock,
             from: cond(


### PR DESCRIPTION
@rgommezz 

## Motivation

If you refer to my Snack repo [here](https://snack.expo.io/@djorkaeff/react-native-scroll-bottom-sheet-issue), you can see that have some weird behaviors at Android, sometimes when you try to go to an intermediate snap, it open at the latest snap point but all the values are at the right point.
I just rollback some commits searching for some code that's working and found this piece of code that fixes the issue, so, I just put it back.
If you have a better solution just let me know.
Thanks in advance.