### PR TITLE
Custom Scroll Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ This is the list of exclusive props that are meant to be used to customise the b
 | `containerStyle`            | no       | `StyleProp<ViewStyle>`  | Style to be applied to the container (Handle and Content) |
 | `friction`                  | no       | `number`      | Factor of resistance when the gesture is released. A value of 0 offers maximum * acceleration, whereas 1 acts as the opposite. Defaults to 0.95 |
 | `enableOverScroll`          | yes      | `boolean`     | Allow drawer to be dragged beyond lowest snap point |
-| `customScrollComponent`     | no       | `ScrollView | FlatList | SectionList` | Custom instance of inner scroll element |
+| `customScrollComponent`     | no       | `ScrollView \| FlatList \| SectionList` | Custom instance of inner scroll element |
 
 ### Inherited
 Depending on the value of `componentType` chosen, the bottom sheet component will inherit its underlying props, being one of

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ This is the list of exclusive props that are meant to be used to customise the b
 | `containerStyle`            | no       | `StyleProp<ViewStyle>`  | Style to be applied to the container (Handle and Content) |
 | `friction`                  | no       | `number`      | Factor of resistance when the gesture is released. A value of 0 offers maximum * acceleration, whereas 1 acts as the opposite. Defaults to 0.95 |
 | `enableOverScroll`          | yes      | `boolean`     | Allow drawer to be dragged beyond lowest snap point |
-
+| `customScrollComponent`     | no       | `ScrollView | FlatList | SectionList` | Custom instance of inner scroll element |
 
 ### Inherited
 Depending on the value of `componentType` chosen, the bottom sheet component will inherit its underlying props, being one of

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -195,7 +195,7 @@ type CommonProps = {
    * Allow drawer to be dragged beyond lowest snap point
    */
   enableOverScroll: boolean;
-  customScrollComponent: any;
+  customScrollComponent?: any;
 };
 
 type TimingAnimationProps = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -198,7 +198,7 @@ type CommonProps = {
   /*
    * Custom inner scrolling component
    */
-  customScrollComponentType: FlatList | ScrollView | SectionList;
+  customScrollComponent: FlatList | ScrollView | SectionList;
 };
 
 type TimingAnimationProps = {
@@ -657,8 +657,8 @@ export class ScrollBottomSheet<T extends any> extends Component<Props<T>> {
   };
 
   private getScrollComponent = () => {
-    if (this.props.customScrollComponentType) {
-      return this.props.customScrollComponentType;
+    if (this.props.customScrollComponent) {
+      return this.props.customScrollComponent;
     }
 
     switch (this.props.componentType) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,6 @@ import Animated, {
   Clock,
   clockRunning,
   cond,
-  debug,
   Easing as EasingDeprecated,
   // @ts-ignore: this property is only present in Reanimated 2
   EasingNode,
@@ -839,7 +838,6 @@ export class ScrollBottomSheet<T extends any> extends Component<Props<T>> {
         />
         <Animated.Code
           exec={onChange(this.isManuallySetValue, [
-            debug('isManuallySetValue', this.isManuallySetValue),
             cond(
               this.isManuallySetValue,
               [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -839,7 +839,7 @@ export class ScrollBottomSheet<T extends any> extends Component<Props<T>> {
         />
         <Animated.Code
           exec={onChange(this.isManuallySetValue, [
-            debug("isManuallySetValue", this.isManuallySetValue),
+            debug('isManuallySetValue', this.isManuallySetValue),
             cond(
               this.isManuallySetValue,
               [


### PR DESCRIPTION
Currently there is no way to integrate a custom keyboard avoiding scrollview into one of the scroll components.

Providing a customScrollComponent would give developers the ability to implement custom components like into the bottom sheet. 
